### PR TITLE
Using https url instead of ssh url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All commands assume to be run inside a cloned version of this repository
 Clone the distributed-wikipedia-mirror git repository
 
 ```sh
-$ git clone git@github.com:ipfs/distributed-wikipedia-mirror.git
+$ git clone https://github.com/ipfs/distributed-wikipedia-mirror.git
 ```
 
 then `cd` into that directory


### PR DESCRIPTION
Using https url could avoid the error like: 
```
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
```