### PR TITLE
style: link to kiwix.org from footer 

### DIFF
--- a/mirrorzim.sh
+++ b/mirrorzim.sh
@@ -92,7 +92,8 @@ TMP_DIRECTORY="./tmp/$(echo $ZIM_FILE | cut -d'.' -f1)"
 # We use it as a hint  if tmpdir  should be purged or not
 
 printf "\nRemove any partial tmp directory $TMP_DIRECTORY before run ..."
-test -e $TMP_DIRECTORY/zimdump_version || rm -rf $TMP_DIRECTORY
+# so.. turns out rsync is the fastest: https://www.slashroot.in/which-is-the-fastest-method-to-delete-files-in-linux
+test -e $TMP_DIRECTORY/zimdump_version || (mkdir -p ./tmp/blank && rsync -a --delete ./tmp/blank/ $TMP_DIRECTORY ; rm -rf $TMP_DIRECTORY ./tmp/blank)
 
 printf "\nUnpack the zim file into $TMP_DIRECTORY if not there already...\n"
 test -e $TMP_DIRECTORY/zimdump_version || (zimdump dump ./snapshots/$ZIM_FILE --dir $TMP_DIRECTORY && zimdump --version > $TMP_DIRECTORY/zimdump_version)

--- a/src/templates/footer_fragment.handlebars
+++ b/src/templates/footer_fragment.handlebars
@@ -117,7 +117,7 @@
         a global effort, independent from Wikipedia.
       </div>
       <div>
-        Created on {{SNAPSHOT_DATE}} from the kiwix ZIM file:
+        Created on {{SNAPSHOT_DATE}} from the <a class="external text" href="https://kiwix.org">Kiwix</a> ZIM file:
         <a href="{{ZIM_URL}}">{{ZIM_NAME}}</a>
       </div>
       <div id="footer-ipns-link">


### PR DESCRIPTION
This PR adds link to kiwix.org under "Kiwix" word as suggested in https://github.com/ipfs/distributed-wikipedia-mirror/issues/60#issuecomment-779564599 
(there is also commit with faster delete because i forgot to push it before submitting this :shrug:)

![Screenshot_2021-02-17 Википєдїꙗ · отврьста єнкѷклопєдїꙗ](https://user-images.githubusercontent.com/157609/108133456-df6fc380-70b4-11eb-8d69-b9c204e2e6d7.png)

@kelson42  Would this work? Lmk if you want to tweak how we present/communicate this.