### PR TITLE
refactor: remove manual redirects fix

### DIFF
--- a/src/site-transforms.ts
+++ b/src/site-transforms.ts
@@ -88,34 +88,6 @@ export const fixFavicon = ({
   cli.action.stop()
 }
 
-
-// Fix any broken redirects (https://github.com/openzim/zim-tools/issues/224)
-export const fixRedirects = async ({
-  unpackedZimDir,
-  wikiFolder
-}: Directories) => {
-  const done = `${unpackedZimDir}/redirects_fixed`
-  if (existsSync(done)) {
-    return
-  }
-
-  cli.action.start('  Fixing redirects ')
-  const fixupLog = `${unpackedZimDir}_redirect-fixups.log`
-  if (existsSync(fixupLog)) {
-    unlinkSync(fixupLog)
-  }
-  const output = process.env.DEBUG ? `>> ${fixupLog}` : '> /dev/null'
-  const util = require('util')
-  const exec = util.promisify(require('child_process').exec)
-  // redirect files are smaller than 1k so we can skip bigger ones, making the performance acceptable
-  const findRedirects = String.raw`find ${wikiFolder} -type f -size -800c -exec fgrep -l "0;url=A/" {} + -exec sed -i "s|0;url=A/|0;url=|" {} + ${output} || true`
-  const { stdout, stderr } = await exec(findRedirects, {env: {'LC_ALL': 'C'}})
-  if (!stderr) closeSync(openSync(done, 'w'))
-  cli.action.stop()
-  if (stdout) console.log('redirect fix stdout:', stdout)
-  if (stderr) console.error('redirect fix stderr:', stderr)
-}
-
 // https://github.com/ipfs/distributed-wikipedia-mirror/issues/80
 export const fixExceptions = async ({
   unpackedZimDir,

--- a/src/zim-to-website.ts
+++ b/src/zim-to-website.ts
@@ -6,7 +6,6 @@ import {
   includeSourceZim,
   copyImageAssetsIntoWiki,
   fixFavicon,
-  fixRedirects,
   fixExceptions,
   generateMainPage,
   insertIndexRedirect,
@@ -50,7 +49,6 @@ export const zimToWebsite = async (options: Options) => {
   fixFavicon(directories)
   moveArticleFolderToWiki(directories)
   await fixExceptions(directories)
-  await fixRedirects(directories)
   insertIndexRedirect(options)
   appendJavascript(options, directories)
   await generateMainPage(options, directories)


### PR DESCRIPTION
Confirmed this is no longer needed, latest zim-tools nightly fixed it upstream.

Closes #86