### PR TITLE
feat: handle _exceptions directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ notes.md
 node_modules
 /zim-tools
 /kiwix-tools
+
+bin/zimdump

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,17 @@ RUN apt update
 RUN apt -y install --no-install-recommends git ca-certificates curl wget apt-utils
 
 # install:
-# - zimdump from zim-tools_linux-x86_64-2021-02-12 (2.2.0 nightly)
 # - node and yarn
 # - go-ipfs
-RUN curl - sL https://ipfs.io/ipfs/QmaXutNuSv9T7w62TzMMKUgtxs9g81GvMt1vKqduLn77Yj -o /usr/local/bin/zimdump \
-    && chmod +x /usr/local/bin/zimdump \
-    && curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh \
+RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh \
     && bash nodesource_setup.sh \
     && apt -y install --no-install-recommends nodejs \
     && npm install -g yarn \
-    && wget -nv https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz \
-    && tar xvfz go-ipfs_v0.7.0_linux-amd64.tar.gz \
+    && wget -nv https://dist.ipfs.io/go-ipfs/v0.8.0/go-ipfs_v0.8.0_linux-amd64.tar.gz \
+    && tar xvfz go-ipfs_v0.8.0_linux-amd64.tar.gz \
     && mv go-ipfs/ipfs /usr/local/bin/ipfs \
-    && rm -r go-ipfs && rm go-ipfs_v0.7.0_linux-amd64.tar.gz \
-    && ipfs init --profile badgerds --empty-repo \
+    && rm -r go-ipfs && rm go-ipfs_v0.8.0_linux-amd64.tar.gz \
+    && ipfs init -p server,local-discovery,flatfs,randomports --empty-repo \
     && ipfs config --json 'Experimental.ShardingEnabled' true
 
 # TODO: move repo init after external volume is mounted

--- a/mirrorzim.sh
+++ b/mirrorzim.sh
@@ -82,8 +82,11 @@ if [ -z ${MAIN_PAGE_VERSION+x} ]; then
 	MAIN_PAGE_VERSION=""
 fi
 
+printf "\nEnsure zimdump is present...\n"
+PATH=$PATH:$(realpath ./bin)
+which zimdump &> /dev/null || (curl --progress-bar -L https://ipfs.io/ipfs/bafybeialu4jsuhs3c3po7juutkwow6kdxeieqcbd6ipjc2tg7qqu7rmsm4 -o ./bin/zimdump && chmod +x ./bin/zimdump)
 
-printf "\nDownload the zim file...\n"
+printf "\nDownload and verify the zim file...\n"
 ZIM_FILE_SOURCE_URL="$(./tools/getzim.sh download $WIKI_TYPE $WIKI_TYPE $LANGUAGE_CODE all maxi latest | grep 'URL:' | cut -d' ' -f3)"
 ZIM_FILE=$(echo $ZIM_FILE_SOURCE_URL | rev | cut -d'/' -f1 | rev)
 TMP_DIRECTORY="./tmp/$(echo $ZIM_FILE | cut -d'.' -f1)"

--- a/mirrorzim.sh
+++ b/mirrorzim.sh
@@ -84,7 +84,7 @@ fi
 
 printf "\nEnsure zimdump is present...\n"
 PATH=$PATH:$(realpath ./bin)
-which zimdump &> /dev/null || (curl --progress-bar -L https://ipfs.io/ipfs/bafybeialu4jsuhs3c3po7juutkwow6kdxeieqcbd6ipjc2tg7qqu7rmsm4 -o ./bin/zimdump && chmod +x ./bin/zimdump)
+which zimdump &> /dev/null || (curl --progress-bar -L https://ipfs.io/ipfs/bafybeibotxexiycu4luq7b6d6sh3oi2t2cvpvbimms6rpmbalbbyfrddyq -o ./bin/zimdump && chmod +x ./bin/zimdump)
 
 printf "\nDownload and verify the zim file...\n"
 ZIM_FILE_SOURCE_URL="$(./tools/getzim.sh download $WIKI_TYPE $WIKI_TYPE $LANGUAGE_CODE all maxi latest | grep 'URL:' | cut -d' ' -f3)"

--- a/src/article-transforms.ts
+++ b/src/article-transforms.ts
@@ -59,6 +59,9 @@ export const moveRelativeLinksUpOneLevel = (href: string) => {
 }
 
 export const moveRelativeLinksDownOneLevel = (href: string) => {
+  if (!(href.startsWith('../') || href.startsWith('http') || href.startsWith('//'))) {
+    return `../${href}`
+  }
   return href.replace('../', '../../')
 }
 

--- a/src/site-transforms.ts
+++ b/src/site-transforms.ts
@@ -148,7 +148,13 @@ export const fixExceptions = async ({
   }
   const dir = opendirSync(exceptionsDir)
   for await (let file of dir) {
-    const articleName = decodeURIComponent(file.name)
+    let articleName
+    try {
+      articleName = decodeURIComponent(file.name)
+    } catch (e) {
+      console.error(`unable to decodeURIComponent(${file.name}): `, e)
+      continue
+    }
     const segments = articleName.split('/')
 
     // only process exceptions from A/ namespace

--- a/src/site-transforms.ts
+++ b/src/site-transforms.ts
@@ -188,6 +188,14 @@ export const resolveDirectories = (options: Options) => {
   return directories
 }
 
+
+// This is usually not used nor needed, but we keep this code around
+// in case we need to generate some language quickly and there is a bug in ZIM
+// that makes main page unusable.
+// With this, we are able to fetch corresponding revision from upstream wikipedia
+// and replace ZIM article with upstream one + fixup links and images.
+// (This is no longer needed for most ZIMs after we switched to upstream zim-tools)
+/*
 export const generateMainPage = async (
   options: Options,
   { wikiFolder, imagesFolder }: Directories
@@ -355,6 +363,7 @@ export const generateMainPage = async (
     cli.error(error)
   }
 }
+*/
 
 export const appendJavscript = (
   options: Options,

--- a/src/site-transforms.ts
+++ b/src/site-transforms.ts
@@ -124,7 +124,7 @@ export const fixExceptions = async ({
     try {
       articleName = decodeURIComponent(file.name)
     } catch (e) {
-      console.error(`unable to decodeURIComponent(${file.name}): `, e)
+      console.error(`[fixExceptions] unable to decodeURIComponent(${file.name}), skipping `)
       continue
     }
     const segments = articleName.split('/')
@@ -137,7 +137,7 @@ export const fixExceptions = async ({
     // and can be represented as directories
     if (!segments.length || segments.some(s => !s.length)) continue
 
-    console.log('processing: ' + articleName)
+    // console.log('processing: ' + articleName)
     const suffixFile = segments.pop() || ''
 
     // creation of index.html breaks links created by zimdump:
@@ -152,8 +152,8 @@ export const fixExceptions = async ({
       reworkScriptSrcs($fileHtml, 'img', linkFixups)
       reworkScriptSrcs($fileHtml, 'script', linkFixups)
 
-      console.log(`    fixed relative paths in ${filePath}`)
-      renameSync(filePath, `${filePath}.original`)
+      // console.log(`    fixed relative paths in ${filePath}`)
+      // renameSync(filePath, `${filePath}.original`)
       writeFileSync(filePath, $fileHtml.html())
     }
 
@@ -162,21 +162,21 @@ export const fixExceptions = async ({
       // ensure dir at each level exists and has no conflict
       for (let i = 1; i < segments.length+1; i++) {
         const parentDir = join(wikiFolder, ...segments.slice(0,i))
-        console.log(' checking parentDir: ' + parentDir)
+        // console.log(' checking parentDir: ' + parentDir)
         if (existsSync(parentDir)) {
           if (lstatSync(parentDir).isFile()) {
             // If a file exists under the name of a directory we need,
             // move file into a newly created dir
             const articleTmp = `${parentDir}.tmp`
             const articleDst = join(parentDir, 'index.html')
-            console.log(`  parentDir is a file, renaming to ${articleDst}`)
+            // console.log(`  parentDir is a file, renaming to ${articleDst}`)
             renameSync(parentDir, articleTmp)
             mkdirSync(parentDir, { recursive: true })
             renameSync(articleTmp, articleDst)
             fixRelativeLinks(articleDst, i)
           }
         } else {
-          console.log(`  created parentDir`)
+          // console.log(`  created parentDir`)
           mkdirSync(parentDir, { recursive: true })
         }
       }
@@ -186,15 +186,15 @@ export const fixExceptions = async ({
     const articleDir = join(wikiFolder, ...segments)
     const articleDst = join(articleDir, suffixFile)
 
-    console.log(` renaming ${articleSrc}`)
+    // console.log(` renaming ${articleSrc}`)
 
     if (existsSync(articleDst) && lstatSync(articleDst).isDirectory()) {
-        console.log(`  directory already, renaming to ${articleDst}/index.html`)
+        // console.log(`  directory already, renaming to ${articleDst}/index.html`)
         const movedArticleDst = join(articleDst, 'index.html')
         renameSync(articleSrc, movedArticleDst)
         fixRelativeLinks(movedArticleDst, 1)
       } else {
-        console.log(`  renamed to ${articleDst}`)
+        // console.log(`  renamed to ${articleDst}`)
         renameSync(articleSrc, articleDst)
       }
     }
@@ -237,6 +237,8 @@ export const insertIndexRedirect = (options: Options) => {
     unlinkSync(wikiIndexPath)
   }
 
+  // note that this is temporary stub, we most likely
+  // override this template with a better landing during later steps
   writeFileSync(
     wikiIndexPath,
     template({
@@ -264,6 +266,82 @@ export const resolveDirectories = (options: Options) => {
   return directories
 }
 
+// Gets path to an article after unpacking and fixExceptions fixups
+const unpackedArticlePath = (wikiFolder: string, article: string) => {
+  let articlePath = join(wikiFolder, article)
+  if (!existsSync(articlePath)) throw new Error(`unpacked '/wiki/${article}' is missing`)
+  if (lstatSync(articlePath).isDirectory()) {
+    const fixedSrc = join(articlePath, 'index.html')
+    if (existsSync(fixedSrc)) {
+      return fixedSrc
+    } else {
+      throw new Error(`unpacked '/wiki/${article}' is a dir without index.html`)
+    }
+  }
+  return articlePath
+}
+
+
+// We copy "kiwix main page" to /wiki/index.html + adjust links.
+// This way original one can still be loaded if needed
+// Example for tr:
+// /wiki/index.html is https://tr.wikipedia.org/wiki/Kullanıcı:The_other_Kiwix_guy/Landing
+// /wiki/Anasayfa is https://tr.wikipedia.org/wiki/Anasayfa
+export const useKiwixLandingPage = async (
+  options: Options,
+  { wikiFolder, imagesFolder }: Directories
+) => {
+
+  cli.action.start(`  Generating landing page at /wiki/ from Kiwix one at /wiki/${options.kiwixMainPage}`)
+
+  const landingPagePath = join(wikiFolder, 'index.html')
+  const originalMainPageSrc = unpackedArticlePath(wikiFolder, options.mainPage)
+  const kiwixMainPageSrc = unpackedArticlePath(wikiFolder, options.kiwixMainPage)
+
+  // Use main page from Kiwix as the landing:
+  // In most cases it is already the best landing available
+  copyFileSync(kiwixMainPageSrc, landingPagePath)
+
+  // Tweak page title of custom landing created by The_other_Kiwix_guy :-)
+  if (kiwixMainPageSrc.includes('The_other_Kiwix_guy') && existsSync(originalMainPageSrc)) {
+    // Set title to one from canonical main page
+    const $landingHtml = cheerio.load(readFileSync(landingPagePath).toString())
+    const canonicalUrlString = $landingHtml('link[rel="canonical"]').attr('href')
+    if (!canonicalUrlString) {
+      throw new Error(`Could not parse out canonical url for ${canonicalUrlString}`)
+    }
+    const canonicalUrl = new URL(canonicalUrlString)
+    canonicalUrl.pathname = `wiki/${options.mainPage}`
+    const response = await fetch(canonicalUrl)
+    const pageBody = await response.text()
+    const $remoteMainPageHtml = cheerio.load(pageBody)
+    const pageTitle = $remoteMainPageHtml('title').text()
+    $landingHtml('title').text(pageTitle)
+    writeFileSync(landingPagePath, $landingHtml.html())
+  }
+
+  // Fixup relative paths, if needed
+  const depth = (options.kiwixMainPage.match(/\//g) || []).length
+  if (depth) {
+    const fixRelativeLinksUp = (filePath: string, depth: number) => {
+      const fileBytes = readFileSync(filePath)
+      const $fileHtml = cheerio.load(fileBytes.toString())
+
+      const linkFixups = Array.from({ length: depth }, (x, i) => moveRelativeLinksUpOneLevel)
+      reworkLinks($fileHtml, 'a:not(a[href^="http"]):not(a[href^="//"])', linkFixups)
+      reworkLinks($fileHtml, 'link[href^="../"]', linkFixups)
+      reworkScriptSrcs($fileHtml, 'img', linkFixups)
+      reworkScriptSrcs($fileHtml, 'script', linkFixups)
+
+      // console.log(`    fixed relative paths in ${filePath}`)
+      // renameSync(filePath, `${filePath}.original`)
+      writeFileSync(filePath, $fileHtml.html())
+    }
+    fixRelativeLinksUp(landingPagePath, depth)
+  }
+
+  cli.action.stop()
+}
 
 // This is usually not used nor needed, but we keep this code around
 // in case we need to generate some language quickly and there is a bug in ZIM
@@ -271,7 +349,8 @@ export const resolveDirectories = (options: Options) => {
 // With this, we are able to fetch corresponding revision from upstream wikipedia
 // and replace ZIM article with upstream one + fixup links and images.
 // (This is no longer needed for most ZIMs after we switched to upstream zim-tools)
-export const generateMainPage = async (
+/*
+export const fetchOriginalMainPage = async (
   options: Options,
   { wikiFolder, imagesFolder }: Directories
 ) => {
@@ -286,24 +365,17 @@ export const generateMainPage = async (
 
   cli.action.start(`  Generating main page into /wiki/`)
 
-  const kiwixMainPageSrc = join(wikiFolder, `${options.kiwixMainPage}`)
+  let kiwixMainPageSrc = join(wikiFolder, `${options.kiwixMainPage}`)
 
-  // This is a crude fix that replaces exploded dir with single html
-  // just to fix main pages that happen to end up in _exceptions.
-  // A proper fix is needed for regular articles:  https://github.com/ipfs/distributed-wikipedia-mirror/issues/80
+  // Handle namespace conflicts resolved in fixExceptions step
   if (lstatSync(kiwixMainPageSrc).isDirectory()) {
-    const exceptionsPage = join(options.unpackedZimDir, '_exceptions', `A%2f${options.kiwixMainPage}`)
-    if (existsSync(exceptionsPage)) {
-      rmdirSync(kiwixMainPageSrc, { recursive: true })
-      copyFileSync(exceptionsPage, kiwixMainPageSrc)
+    const fixedSrc = `${kiwixMainPageSrc}/index.html`
+    if (existsSync(fixedSrc)) {
+      kiwixMainPageSrc = fixedSrc
+    } else {
+      throw new Error(`kiwixMainPageSrc "${kiwixMainPageSrc}" is a dir without index.html`)
     }
   }
-
-  cli.action.stop()
-
-/*
-
-  cli.action.start(`  Generating main page into ${mainPagePath} `)
 
   const kiwixMainpage = readFileSync(kiwixMainPageSrc)
 
@@ -344,7 +416,7 @@ export const generateMainPage = async (
     const $remoteMainPageHtml = cheerio.load(pageBody)
 
     const $remoteContent = $remoteMainPageHtml('#content')
-    const remotePageTitle = $remoteMainPageHtml('title').text()
+    const remotePageTitle = $remoteMainPageHtml('title').text().replace(':The other Kiwix guy/', '')
 
     $remoteContent.addClass('content')
     $remoteContent.find('#siteNotice').remove()
@@ -443,8 +515,8 @@ export const generateMainPage = async (
   } catch (error) {
     cli.error(error)
   }
-  */
 }
+*/
 
 export const appendJavscript = (
   options: Options,

--- a/src/site-transforms.ts
+++ b/src/site-transforms.ts
@@ -89,34 +89,6 @@ export const fixFavicon = ({
   cli.action.stop()
 }
 
-
-// Fix any broken redirects (https://github.com/openzim/zim-tools/issues/224)
-export const fixRedirects = async ({
-  unpackedZimDir,
-  wikiFolder
-}: Directories) => {
-  const done = `${unpackedZimDir}/redirects_fixed`
-  if (existsSync(done)) {
-    return
-  }
-
-  cli.action.start('  Fixing redirects ')
-  const fixupLog = `${unpackedZimDir}_redirect-fixups.log`
-  if (existsSync(fixupLog)) {
-    unlinkSync(fixupLog)
-  }
-  const output = process.env.DEBUG ? `>> ${fixupLog}` : '> /dev/null'
-  const util = require('util')
-  const exec = util.promisify(require('child_process').exec)
-  // redirect files are smaller than 1k so we can skip bigger ones, making the performance acceptable
-  const findRedirects = String.raw`find ${wikiFolder} -type f -size -800c -exec fgrep -l "0;url=A/" {} + -exec sed -i "s|0;url=A/|0;url=|" {} + ${output} || true`
-  const { stdout, stderr } = await exec(findRedirects, {env: {'LC_ALL': 'C'}})
-  if (!stderr) closeSync(openSync(done, 'w'))
-  cli.action.stop()
-  if (stdout) console.log('redirect fix stdout:', stdout)
-  if (stderr) console.error('redirect fix stderr:', stderr)
-}
-
 // https://github.com/ipfs/distributed-wikipedia-mirror/issues/80
 export const fixExceptions = async ({
   unpackedZimDir,

--- a/src/site-transforms.ts
+++ b/src/site-transforms.ts
@@ -88,6 +88,34 @@ export const fixFavicon = ({
   cli.action.stop()
 }
 
+
+// Fix any broken redirects (https://github.com/openzim/zim-tools/issues/224)
+export const fixRedirects = async ({
+  unpackedZimDir,
+  wikiFolder
+}: Directories) => {
+  const done = `${unpackedZimDir}/redirects_fixed`
+  if (existsSync(done)) {
+    return
+  }
+
+  cli.action.start('  Fixing redirects ')
+  const fixupLog = `${unpackedZimDir}_redirect-fixups.log`
+  if (existsSync(fixupLog)) {
+    unlinkSync(fixupLog)
+  }
+  const output = process.env.DEBUG ? `>> ${fixupLog}` : '> /dev/null'
+  const util = require('util')
+  const exec = util.promisify(require('child_process').exec)
+  // redirect files are smaller than 1k so we can skip bigger ones, making the performance acceptable
+  const findRedirects = String.raw`find ${wikiFolder} -type f -size -800c -exec fgrep -l "0;url=A/" {} + -exec sed -i "s|0;url=A/|0;url=|" {} + ${output} || true`
+  const { stdout, stderr } = await exec(findRedirects, {env: {'LC_ALL': 'C'}})
+  if (!stderr) closeSync(openSync(done, 'w'))
+  cli.action.stop()
+  if (stdout) console.log('redirect fix stdout:', stdout)
+  if (stderr) console.error('redirect fix stderr:', stderr)
+}
+
 // https://github.com/ipfs/distributed-wikipedia-mirror/issues/80
 export const fixExceptions = async ({
   unpackedZimDir,

--- a/src/zim-to-website.ts
+++ b/src/zim-to-website.ts
@@ -6,6 +6,7 @@ import {
   includeSourceZim,
   copyImageAssetsIntoWiki,
   fixFavicon,
+  fixRedirects,
   fixExceptions,
   // generateMainPage,
   insertIndexRedirect,
@@ -49,6 +50,7 @@ export const zimToWebsite = async (options: Options) => {
   fixFavicon(directories)
   moveArticleFolderToWiki(directories)
   await fixExceptions(directories)
+  await fixRedirects(directories)
   insertIndexRedirect(options)
   appendJavascript(options, directories)
   // usually main page is ok, so we dont need below

--- a/src/zim-to-website.ts
+++ b/src/zim-to-website.ts
@@ -6,7 +6,6 @@ import {
   includeSourceZim,
   copyImageAssetsIntoWiki,
   fixFavicon,
-  fixRedirects,
   fixExceptions,
   // generateMainPage,
   insertIndexRedirect,
@@ -50,7 +49,6 @@ export const zimToWebsite = async (options: Options) => {
   fixFavicon(directories)
   moveArticleFolderToWiki(directories)
   await fixExceptions(directories)
-  await fixRedirects(directories)
   insertIndexRedirect(options)
   appendJavascript(options, directories)
   // usually main page is ok, so we dont need below

--- a/src/zim-to-website.ts
+++ b/src/zim-to-website.ts
@@ -8,6 +8,7 @@ import {
   fixFavicon,
   fixExceptions,
   // generateMainPage,
+  useKiwixLandingPage,
   insertIndexRedirect,
   moveArticleFolderToWiki,
   resolveDirectories
@@ -51,7 +52,9 @@ export const zimToWebsite = async (options: Options) => {
   await fixExceptions(directories)
   insertIndexRedirect(options)
   appendJavascript(options, directories)
-  // usually main page is ok, so we dont need below
+  await useKiwixLandingPage(options, directories)
+
+  // usually main page from kiwix is ok, so we dont need below
   // await generateMainPage(options, directories)
 
   cli.log('done')

--- a/src/zim-to-website.ts
+++ b/src/zim-to-website.ts
@@ -7,7 +7,7 @@ import {
   copyImageAssetsIntoWiki,
   fixFavicon,
   fixExceptions,
-  generateMainPage,
+  // generateMainPage,
   insertIndexRedirect,
   moveArticleFolderToWiki,
   resolveDirectories
@@ -24,8 +24,8 @@ export const zimToWebsite = async (options: Options) => {
   cli.log('-------------------------')
   cli.log(`  Unpacked Zim Directory: ${options.unpackedZimDir}`)
   cli.log(`                Zim File: ${options.zimFile}`)
-  cli.log(`               Main Page: ${options.mainPage}`)
-  cli.log(`         Kiwix Main Page: ${options.kiwixMainPage}`)
+  cli.log(`      Original Main Page: ${options.mainPage ? decodeURIComponent(options.mainPage) : null}`)
+  cli.log(`         ZIM's Main Page: ${options.kiwixMainPage}`)
 
   if (options.hostingDNSDomain) {
     cli.log(`      Hosting DNS Domain: ${options.hostingDNSDomain}`)
@@ -51,7 +51,8 @@ export const zimToWebsite = async (options: Options) => {
   await fixExceptions(directories)
   insertIndexRedirect(options)
   appendJavascript(options, directories)
-  await generateMainPage(options, directories)
+  // usually main page is ok, so we dont need below
+  // await generateMainPage(options, directories)
 
   cli.log('done')
 }

--- a/tools/getzim.sh
+++ b/tools/getzim.sh
@@ -239,7 +239,7 @@ cmd_download_url() {
   log "URL: $URL"
 
   # below is a mixture of https://stackoverflow.com/a/19841872/3990041, my knowledge and guesswork :P
-  SHA256=$(curl -sI "$URL" | grep digest | grep "SHA-256" | sed "s|digest: SHA-256=||g" | base64 -d | od -t x1 -An | tr "\n" " " | sed "s| ||g")
+  SHA256=$(curl -sI "$URL" | grep digest | grep "SHA-256" | sed "s|digest: SHA-256=||g" | base64 -d -i | od -t x1 -An | tr "\n" " " | sed "s| ||g")
 
   log "SHA256: $SHA256"
 }
@@ -257,7 +257,7 @@ cmd_download() {
 
   dl_cycle() {
     log "Downloading $OUTNAME..."
-    wget --continue -P ./snapshots "$URL"
+    wget --continue -q --show-progress --progress=bar:force -P ./snapshots "$URL"
     return $?
   }
 


### PR DESCRIPTION
This PR closes #80 and also closes some side-quests:

- [x] process `_exceptions` directory and fix where possible
  - in case of English snapshot for 2021-02 there are about 16k of exceptions, so it is acceptable to fix them manually 
  - this PR fixes most of them (about 300 remain, but that can be tackled in separate PR)
  - example:
    - https://bafybeibbyehjtwu7t2atztquwmhqrc5cg6uvo4hnvyd52suv5t4ilm2otq.ipfs.dweb.link/wiki/Asia/ is fixed
    - https://bafybeibbyehjtwu7t2atztquwmhqrc5cg6uvo4hnvyd52suv5t4ilm2otq.ipfs.dweb.link/wiki/Asia/Tokyo redirects correctly too
- [x] do not crash when filename is not properly urlencoded (https://github.com/ipfs/distributed-wikipedia-mirror/commit/919bc272c2f555439b396ace3f489c0c25eca7f5)
- [x] remove redirect fix and switch to latest `zimdump` that does the fix upstream
- [x] fix bogus stderr on sha verification
- [x] experiment with non-generated main page
  - not tragic, but not really happy with how original one looks (English): https://bafybeibbyehjtwu7t2atztquwmhqrc5cg6uvo4hnvyd52suv5t4ilm2otq.ipfs.dweb.link/wiki/Main_Page/
  - Kiwix variant is better: https://bafybeibbyehjtwu7t2atztquwmhqrc5cg6uvo4hnvyd52suv5t4ilm2otq.ipfs.dweb.link/wiki/User:The_other_Kiwix_guy/Landing
  - I'll switch generator to put the latter  under https://bafybeibbyehjtwu7t2atztquwmhqrc5cg6uvo4hnvyd52suv5t4ilm2otq.ipfs.dweb.link/wiki/ so the default landing is nice + original one can be accessed if needed. 