### PR TITLE
fix: redirects converted from _exceptions

### DIFF
--- a/src/article-transforms.ts
+++ b/src/article-transforms.ts
@@ -130,3 +130,31 @@ export const reworkScriptSrcs = (
     attribs.src = src
   }
 }
+
+export const reworkRedirect = (
+  $html: any,
+  selector = 'meta[http-equiv="refresh"]',
+  fns: ((href: string) => string)[] = [
+    moveRelativeLinksDownOneLevel
+  ]
+) => {
+  const redirects = $html(selector)
+
+  for (const redirect of Object.values<any>(redirects)) {
+    const attribs = redirect.attribs
+
+    if (!attribs || !attribs.content) {
+      continue
+    }
+
+    let { content } = attribs
+
+    let [ delay, url ] = content.split(';url=')
+
+    for (const fn of fns) {
+      url = fn(url)
+    }
+
+    attribs.content = `${delay};url=${url}`
+  }
+}

--- a/src/site-transforms.ts
+++ b/src/site-transforms.ts
@@ -28,7 +28,8 @@ import {
   moveRelativeLinksDownOneLevel,
   prefixRelativeRoot,
   reworkLinks,
-  reworkScriptSrcs
+  reworkScriptSrcs,
+  reworkRedirect
 } from './article-transforms'
 import { Directories, Options } from './domain'
 import { downloadFile } from './utils/download-file'
@@ -151,6 +152,7 @@ export const fixExceptions = async ({
       reworkLinks($fileHtml, 'link[href^="../"]', linkFixups)
       reworkScriptSrcs($fileHtml, 'img', linkFixups)
       reworkScriptSrcs($fileHtml, 'script', linkFixups)
+      reworkRedirect($fileHtml, 'meta[http-equiv="refresh"]', linkFixups)
 
       // console.log(`    fixed relative paths in ${filePath}`)
       // renameSync(filePath, `${filePath}.original`)


### PR DESCRIPTION
This PR closes #89

Example of  a fixed redirect that points at other resolved _exception, and both work fine together: 

- https://bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze.ipfs.dweb.link/wiki/United_States_of_America  
  - https://bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze.ipfs.dweb.link/wiki/United_States_of_America/ (directory, reading `index.html`) 
    - https://bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze.ipfs.dweb.link/wiki/United_States/ (also a dir with `index.html`) 