### PR TITLE
feat: add wikipedia_zh_all_maxi_2021-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,17 @@
 Putting Wikipedia Snapshots on IPFS and working towards making it fully read-write.
 <br />
 <br />
- Existing Mirrors: https://en.wikipedia-on-ipfs.org, https://tr.wikipedia-on-ipfs.org, https://my.wikipedia-on-ipfs.org
-</p>
+
+## Existing Mirrors
+
+- https://en.wikipedia-on-ipfs.org
+- https://tr.wikipedia-on-ipfs.org
+- https://my.wikipedia-on-ipfs.org
+- https://zh.wikipedia-on-ipfs.org
+
+Each mirror has a link to original [Kiwix](https://kiwix.org) ZIM archive in the footer.
+
+## Table of Contents
 
 - [Purpose](#purpose)
 - [How to add new Wikipedia snapshots to IPFS](#how-to-add-new-wikipedia-snapshots-to-ipfs)

--- a/snapshot-hashes.yml
+++ b/snapshot-hashes.yml
@@ -20,3 +20,9 @@ my:
   date: 2021-02-22
   ipns:
   ipfs: https://dweb.link/ipfs/bafybeib66xujztkiq7lqbupfz6arzhlncwagva35dx54nj7ipyoqpyozhy
+zh:
+  name: Chinese
+  original: zh.wikipedia.org
+  date: 2021-03-16
+  ipns:
+  ipfs: https://dweb.link/ipfs/bafybeiazgazbrj6qprr4y5hx277u4g2r5nzgo3jnxkhqx56doxdqrzms6y


### PR DESCRIPTION
This PR adds zh version and closes #74

Generated from `wikipedia_zh_all_maxi_2021-02.zim`, includes various fixes on top of test build from https://github.com/ipfs/distributed-wikipedia-mirror/issues/74#issuecomment-783143063, including #90: 

- https://dweb.link/ipfs/bafybeiazgazbrj6qprr4y5hx277u4g2r5nzgo3jnxkhqx56doxdqrzms6y

@kelson42  @FledgeXu mind checking if the above snapshot looks good?

If it loads slow from gateway, try to connect to the origin node via
`ipfs swarm connect /p2p/12D3KooWA4qoLqDDjdozHuVjiXDq2xu9iggDkcwntdXvkQ7JyW56`

Thanks!


## TODO

- [x] get OK from native  speaker
- [x] pin
- [x] update DNSLink
- [x] add to https://collab.ipfscluster.io/