### PR TITLE
feat: wikipedia_en_all_maxi_2021-02

### DIFF
--- a/snapshot-hashes.yml
+++ b/snapshot-hashes.yml
@@ -5,9 +5,9 @@
 en:
   name: English
   original: en.wikipedia.org
-  date: 2017-05-11
+  date: 2021-03-09
   ipns:
-  ipfs: https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco
+  ipfs: https://dweb.link/ipfs/bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze
 tr:
   name: Turkish
   original: tr.wikipedia.org


### PR DESCRIPTION
This PR updates English  version to snapshot from 2021-02 and closes #61

Generated from `wikipedia_en_all_maxi_2021-02.zim`, includes fix from  #90: 

- https://dweb.link/ipfs/bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze

If it loads slow from gateway, try to connect to the origin node via
`ipfs swarm connect /p2p/12D3KooWFRcqpEhdCfAY6HYcrJaQjDBbPNp2ycxDY54LZNx6UgLM`

Thanks!

## TODO

- [x] get OK from native  speaker
  - Before we pin this,  @kelson42  @mburns @autonome mind checking if the above snapshot looks good and give final OK?
- [x] pin
  - (after I have pin confirmation, I can remove `en` from my SSD and bulid `ru` and `ar` )
- [x] update DNSLink
- [x] add to https://collab.ipfscluster.io/