### PR TITLE
feat: add wikipedia_ru_all_maxi_2021-03

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,6 @@
+Below are some quick notes on how long things take.
+
+- 2021-Q1 with 1TB NVMe SSD, i7-4770S
+  - unpacking wikipedia_en_all_maxi_2021-02 + fixing exceptions  on ssd ~3h50m
+    (not a full build, this is without IPFS import)
+  - full build from wikipedia_ru_all_maxi_2021-03.zim with badger ~4h11m

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Putting Wikipedia Snapshots on IPFS and working towards making it fully read-wri
 - https://tr.wikipedia-on-ipfs.org
 - https://my.wikipedia-on-ipfs.org
 - https://zh.wikipedia-on-ipfs.org
+- https://ru.wikipedia-on-ipfs.org
 
 Each mirror has a link to original [Kiwix](https://kiwix.org) ZIM archive in the footer.
 

--- a/snapshot-hashes.yml
+++ b/snapshot-hashes.yml
@@ -5,24 +5,35 @@
 en:
   name: English
   original: en.wikipedia.org
+  source:
   date: 2017-05-11
   ipns:
   ipfs: https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco
 tr:
   name: Turkish
   original: tr.wikipedia.org
+  source: wikipedia_tr_all_maxi_2021-02.zim
   date: 2021-02-19
   ipns:
   ipfs: https://dweb.link/ipfs/bafybeieuutdavvf55sh3jktq2dpi2hkle6dtmebe7uklod3ramihyf3xa4
 my:
   name: Myanmar
   original: my.wikipedia.org
+  source: wikipedia_my_all_maxi_2021-02.zim
   date: 2021-02-22
   ipns:
   ipfs: https://dweb.link/ipfs/bafybeib66xujztkiq7lqbupfz6arzhlncwagva35dx54nj7ipyoqpyozhy
 zh:
   name: Chinese
   original: zh.wikipedia.org
+  source: wikipedia_zh_all_maxi_2021-02.zim
   date: 2021-03-16
   ipns:
   ipfs: https://dweb.link/ipfs/bafybeiazgazbrj6qprr4y5hx277u4g2r5nzgo3jnxkhqx56doxdqrzms6y
+ru:
+  name: Russian
+  original: ru.wikipedia.org
+  source: wikipedia_ru_all_maxi_2021-03.zim
+  date: 2021-03-25
+  ipns:
+  ipfs: https://dweb.link/ipfs/bafybeieto6mcuvqlechv4iadoqvnffondeiwxc2bcfcewhvpsd2odvbmvm


### PR DESCRIPTION
This PR adds `ru` version generated from `wikipedia_ru_all_maxi_2021-03.zim`:

- https://dweb.link/ipfs/bafybeieto6mcuvqlechv4iadoqvnffondeiwxc2bcfcewhvpsd2odvbmvm

If it loads slow from gateway, try to connect to the origin node via
`ipfs swarm connect /p2p/12D3KooWR81DyobWoLV8H42jEgfdVoYXjxe9PRtJmgSTZTNSR8ua`

## TODO

- [x] get OK from native  speaker
- [x] pin to https://collab.ipfscluster.io
- [x] update DNSLink