### PR TITLE
feat: add wikipedia_ar_all_maxi_2021-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Putting Wikipedia Snapshots on IPFS and working towards making it fully read-wri
 - https://en.wikipedia-on-ipfs.org
 - https://tr.wikipedia-on-ipfs.org
 - https://my.wikipedia-on-ipfs.org
+- https://ar.wikipedia-on-ipfs.org
 - https://zh.wikipedia-on-ipfs.org
 
 Each mirror has a link to original [Kiwix](https://kiwix.org) ZIM archive in the footer.

--- a/snapshot-hashes.yml
+++ b/snapshot-hashes.yml
@@ -20,6 +20,13 @@ my:
   date: 2021-02-22
   ipns:
   ipfs: https://dweb.link/ipfs/bafybeib66xujztkiq7lqbupfz6arzhlncwagva35dx54nj7ipyoqpyozhy
+ar:
+  name: Arabic
+  original: ar.wikipedia.org
+  source: wikipedia_ar_all_maxi_2021-03.zim
+  date: 2021-03-26
+  ipns:
+  ipfs: https://dweb.link/ipfs/bafybeih4a6ylafdki6ailjrdvmr7o4fbbeceeeuty4v3qyyouiz5koqlpi
 zh:
   name: Chinese
   original: zh.wikipedia.org


### PR DESCRIPTION
This PR adds `ar` version generated from `wikipedia_ar_all_maxi_2021-03.zim`:

- https://dweb.link/ipfs/bafybeih4a6ylafdki6ailjrdvmr7o4fbbeceeeuty4v3qyyouiz5koqlpi

If it loads slow from gateway, try to connect to the origin node via
`ipfs swarm connect /p2p/12D3KooWJNDFRRjrmffWC2HWurKoVd8y1KvBdqULWWayVas8spin`

## TODO

- [ ] get OK from native  speaker
- [x] pin to https://collab.ipfscluster.io
- [x] update DNSLink