### PR TITLE
refactor: cleanup hashes file

### DIFF
--- a/snapshot-hashes.yml
+++ b/snapshot-hashes.yml
@@ -1,6 +1,7 @@
 %YAML 1.2
 ---
-# TODO: link here to the blog post explaining how to access mirror via DNSLink and CID
+# How to access mirror via DNSLink and CID?
+#  https://blog.ipfs.io/2021-05-31-distributed-wikipedia-mirror-update/#improved-access-to-wikipedia-mirrors
 
 en:
   name: English

--- a/snapshot-hashes.yml
+++ b/snapshot-hashes.yml
@@ -1,46 +1,52 @@
 %YAML 1.2
 ---
-# This is a stopgap measure for keeping track of hashes until we set up a better system.
+# TODO: link here to the blog post explaining how to access mirror via DNSLink and CID
 
 en:
   name: English
   original: en.wikipedia.org
-  date: 2021-03-09
-  source: wikipedia_en_all_maxi_2021-02.zim
-  ipns:
-  ipfs: https://dweb.link/ipfs/bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze
+  dnslink: en.wikipedia-on-ipfs.org
+  snapshot:
+    date: 2021-03-09
+    source: wikipedia_en_all_maxi_2021-02.zim
+    cid: bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze
 tr:
   name: Turkish
   original: tr.wikipedia.org
-  source: wikipedia_tr_all_maxi_2021-02.zim
-  date: 2021-02-19
-  ipns:
-  ipfs: https://dweb.link/ipfs/bafybeieuutdavvf55sh3jktq2dpi2hkle6dtmebe7uklod3ramihyf3xa4
+  dnslink: tr.wikipedia-on-ipfs.org
+  snapshot:
+    date: 2021-02-19
+    source: wikipedia_tr_all_maxi_2021-02.zim
+    cid: bafybeieuutdavvf55sh3jktq2dpi2hkle6dtmebe7uklod3ramihyf3xa4
 my:
   name: Myanmar
   original: my.wikipedia.org
-  source: wikipedia_my_all_maxi_2021-02.zim
-  date: 2021-02-22
-  ipns:
-  ipfs: https://dweb.link/ipfs/bafybeib66xujztkiq7lqbupfz6arzhlncwagva35dx54nj7ipyoqpyozhy
+  dnslink: my.wikipedia-on-ipfs.org
+  snapshot:
+    date: 2021-02-22
+    source: wikipedia_my_all_maxi_2021-02.zim
+    cid: bafybeib66xujztkiq7lqbupfz6arzhlncwagva35dx54nj7ipyoqpyozhy
 ar:
   name: Arabic
   original: ar.wikipedia.org
-  source: wikipedia_ar_all_maxi_2021-03.zim
-  date: 2021-03-26
-  ipns:
-  ipfs: https://dweb.link/ipfs/bafybeih4a6ylafdki6ailjrdvmr7o4fbbeceeeuty4v3qyyouiz5koqlpi
+  dnslink: ar.wikipedia-on-ipfs.org
+  snapshot:
+    source: wikipedia_ar_all_maxi_2021-03.zim
+    date: 2021-03-26
+    cid: bafybeih4a6ylafdki6ailjrdvmr7o4fbbeceeeuty4v3qyyouiz5koqlpi
 zh:
   name: Chinese
   original: zh.wikipedia.org
-  source: wikipedia_zh_all_maxi_2021-02.zim
-  date: 2021-03-16
-  ipns:
-  ipfs: https://dweb.link/ipfs/bafybeiazgazbrj6qprr4y5hx277u4g2r5nzgo3jnxkhqx56doxdqrzms6y
+  dnslink: zh.wikipedia-on-ipfs.org
+  snapshot:
+    date: 2021-03-16
+    source: wikipedia_zh_all_maxi_2021-02.zim
+    cid: bafybeiazgazbrj6qprr4y5hx277u4g2r5nzgo3jnxkhqx56doxdqrzms6y
 ru:
   name: Russian
   original: ru.wikipedia.org
-  source: wikipedia_ru_all_maxi_2021-03.zim
-  date: 2021-03-25
-  ipns:
-  ipfs: https://dweb.link/ipfs/bafybeieto6mcuvqlechv4iadoqvnffondeiwxc2bcfcewhvpsd2odvbmvm
+  dnslink: ru.wikipedia-on-ipfs.org
+  snapshot:
+    date: 2021-03-25
+    source: wikipedia_ru_all_maxi_2021-03.zim
+    cid: bafybeieto6mcuvqlechv4iadoqvnffondeiwxc2bcfcewhvpsd2odvbmvm


### PR DESCRIPTION
This PR makes clean distinction which identifiers are specific to the latest snapshot (cid, source) and which one remain static (dnslink).

The idea here is to leverage a blogpost (WIP) to explain how to load content using values from `dnslink` or  `cid`.