### PR TITLE
fix: main page in case it was created from exception

### DIFF
--- a/src/site-transforms.ts
+++ b/src/site-transforms.ts
@@ -322,7 +322,7 @@ export const useKiwixLandingPage = async (
   }
 
   // Fixup relative paths, if needed
-  const depth = (options.kiwixMainPage.match(/\//g) || []).length
+  const depth = (kiwixMainPageSrc.substring(wikiFolder.length + 1).match(/\//g) || []).length
   if (depth) {
     const fixRelativeLinksUp = (filePath: string, depth: number) => {
       const fileBytes = readFileSync(filePath)


### PR DESCRIPTION
This fixes the issues that affected Belarusian wiki for example - https://github.com/ipfs/distributed-wikipedia-mirror/pull/120

In case of Belarusian wiki, the main page lands in exceptions. This means that in the resulting website it's available under `wiki/main_page/index.html` instead of `wiki/main_page`.

When it's copied to `wiki/index.html`, one depth level in relative links have to be removed. 

Previously, we were looking at the input main page path to determine if relative links need to be fixed up. With this change, we will be looking at the actual path (e.g. after exceptions processing).

######
This fix was tested as part of https://github.com/ipfs/distributed-wikipedia-mirror/pull/123.